### PR TITLE
Add `ignore_caster_error` parameter for Field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test:
 	$(py) pytest
 
 black:
-	$(py) black betterconf/
+	$(py) black betterconf/ tests/
 
 pre-commit:
 	$(py) pre-commit install

--- a/betterconf/caster.py
+++ b/betterconf/caster.py
@@ -17,7 +17,7 @@ class ConstantCaster(AbstractCaster, typing.Generic[VT]):
         typing.Union[str, typing.Tuple[str, ...]], typing.Any
     ] = {}
 
-    def cast(self, val: str) -> typing.Union[ImpossibleToCastError, VT]:
+    def cast(self, val: str) -> typing.Union[VT, typing.NoReturn]:
         """Cast using ABLE_TO_CAST dictionary as in BoolCaster"""
         if val in self.ABLE_TO_CAST:
             converted = self.ABLE_TO_CAST.get(val.lower())
@@ -48,7 +48,7 @@ class BoolCaster(ConstantCaster):
 
 
 class IntCaster(AbstractCaster):
-    def cast(self, val: str) -> typing.Union[int, ImpossibleToCastError]:
+    def cast(self, val: str) -> typing.Union[int, typing.NoReturn]:
         try:
             as_int = int(val)
             return as_int

--- a/betterconf/caster.py
+++ b/betterconf/caster.py
@@ -1,5 +1,7 @@
 import typing
 
+from betterconf.exceptions import ImpossibleToCastError
+
 VT = typing.TypeVar("VT")
 
 
@@ -15,7 +17,7 @@ class ConstantCaster(AbstractCaster, typing.Generic[VT]):
         typing.Union[str, typing.Tuple[str, ...]], typing.Any
     ] = {}
 
-    def cast(self, val: str) -> typing.Union[str, VT]:
+    def cast(self, val: str) -> typing.Union[ImpossibleToCastError, VT]:
         """Cast using ABLE_TO_CAST dictionary as in BoolCaster"""
         if val in self.ABLE_TO_CAST:
             converted = self.ABLE_TO_CAST.get(val.lower())
@@ -27,7 +29,7 @@ class ConstantCaster(AbstractCaster, typing.Generic[VT]):
                     return self.ABLE_TO_CAST[key]
                 elif isinstance(key, str) and val.lower() == key:
                     return self.ABLE_TO_CAST[key]
-            return val
+            return ImpossibleToCastError(val, self)
 
 
 class BoolCaster(ConstantCaster):
@@ -46,12 +48,12 @@ class BoolCaster(ConstantCaster):
 
 
 class IntCaster(AbstractCaster):
-    def cast(self, val: str) -> typing.Union[str, int]:
+    def cast(self, val: str) -> typing.Union[int, ImpossibleToCastError]:
         try:
             as_int = int(val)
             return as_int
         except ValueError:
-            return val
+            return ImpossibleToCastError(val, self)
 
 
 class NothingCaster(AbstractCaster):

--- a/betterconf/caster.py
+++ b/betterconf/caster.py
@@ -29,7 +29,7 @@ class ConstantCaster(AbstractCaster, typing.Generic[VT]):
                     return self.ABLE_TO_CAST[key]
                 elif isinstance(key, str) and val.lower() == key:
                     return self.ABLE_TO_CAST[key]
-            return ImpossibleToCastError(val, self)
+            raise ImpossibleToCastError(val, self)
 
 
 class BoolCaster(ConstantCaster):
@@ -53,7 +53,7 @@ class IntCaster(AbstractCaster):
             as_int = int(val)
             return as_int
         except ValueError:
-            return ImpossibleToCastError(val, self)
+            raise ImpossibleToCastError(val, self)
 
 
 class NothingCaster(AbstractCaster):

--- a/betterconf/config.py
+++ b/betterconf/config.py
@@ -59,13 +59,15 @@ class Field:
                 return self._default()
             else:
                 return self._default
-        casted = self._caster.cast(self._value)
-        if isinstance(casted, ImpossibleToCastError):
+        try:
+            casted = self._caster.cast(self._value)
+
+        except ImpossibleToCastError as e:
             if self._ignore_caster_error:
-                return casted.val
+                return e.val
 
             else:
-                raise casted
+                raise e
 
         else:
             return casted

--- a/betterconf/exceptions.py
+++ b/betterconf/exceptions.py
@@ -6,12 +6,12 @@ class ImpossibleToCastError(BetterconfError):
     def __init__(self, val: str, caster: object):
         self.val = val
         self.caster = caster
-        self.message = 'Could not cast "{}" with {}'.format(val, caster.__class__.__name__)
+        self.message = f'Could not cast "{val}" with {caster.__class__.__name__}'
         super().__init__(self.message)
 
 
 class VariableNotFoundError(BetterconfError):
     def __init__(self, variable_name: str):
         self.variable_name = variable_name
-        self.message = "Variable ({}) hasn't been found".format(variable_name)
+        self.message = f"Variable ({variable_name}) hasn't been found"
         super().__init__(self.message)

--- a/betterconf/exceptions.py
+++ b/betterconf/exceptions.py
@@ -5,13 +5,13 @@ class BetterconfError(Exception):
 class ImpossibleToCastError(BetterconfError):
     def __init__(self, val: str, caster: object):
         self.val = val
-        self.caster_name = caster.__class__.__name__
-        self.message = 'Could not cast "{}" with {}'.format(self.val, self.caster_name)
+        self.caster = caster
+        self.message = 'Could not cast "{}" with {}'.format(val, caster.__class__.__name__)
         super().__init__(self.message)
 
 
 class VariableNotFoundError(BetterconfError):
     def __init__(self, variable_name: str):
-        self.var_name = variable_name
+        self.variable_name = variable_name
         self.message = "Variable ({}) hasn't been found".format(variable_name)
         super().__init__(self.message)

--- a/betterconf/exceptions.py
+++ b/betterconf/exceptions.py
@@ -1,0 +1,17 @@
+class BetterconfError(Exception):
+    pass
+
+
+class ImpossibleToCastError(BetterconfError):
+    def __init__(self, val: str, caster: object):
+        self.val = val
+        self.caster_name = caster.__class__.__name__
+        self.message = 'Could not cast "{}" with {}'.format(self.val, self.caster_name)
+        super().__init__(self.message)
+
+
+class VariableNotFoundError(BetterconfError):
+    def __init__(self, variable_name: str):
+        self.var_name = variable_name
+        self.message = "Variable ({}) hasn't been found".format(variable_name)
+        super().__init__(self.message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "betterconf"
-version = "2.5.1"
+version = "2.6"
 description = "Minimalistic Python library for your configs."
 authors = ["prostomarkeloff"]
 license = "MIT"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,33 +16,33 @@ VAR_1_VALUE = "hello!#"
 
 
 class TestConfig(Config):
-    debug = field('DEBUG', default=False, caster=to_bool)
+    debug = field("DEBUG", default=False, caster=to_bool)
 
     class Sub1Config:
         class Sub2Config:
-            config_1 = field(default='base.mail.com')
-            config_2 = field(default='465')
-            config_3 = field(default='test')
+            config_1 = field(default="base.mail.com")
+            config_2 = field(default="465")
+            config_3 = field(default="test")
 
 
 class ProdConfig(TestConfig):
-    _prefix_ = 'PROD'
+    _prefix_ = "PROD"
 
     class Sub1Config(TestConfig.Sub1Config):
         class Sub2Config(TestConfig.Sub1Config.Sub2Config):
-            config_1 = field(default='prod.mail.com')
-            config_2 = field(default='465')
+            config_1 = field(default="prod.mail.com")
+            config_2 = field(default="465")
 
 
 @pytest.fixture
 def update_environ():
-    os.environ['DEBUG'] = 'true'
-    os.environ['SUB1CONFIG_SUB2CONFIG_CONFIG_1'] = 'test.mail.com'
-    os.environ['PROD_SUB1CONFIG_SUB2CONFIG_CONFIG_2'] = '100202'
+    os.environ["DEBUG"] = "true"
+    os.environ["SUB1CONFIG_SUB2CONFIG_CONFIG_1"] = "test.mail.com"
+    os.environ["PROD_SUB1CONFIG_SUB2CONFIG_CONFIG_2"] = "100202"
     yield
-    os.environ.pop('DEBUG', None)
-    os.environ.pop('SUB1CONFIG_SUB2CONFIG_CONFIG_1', None)
-    os.environ.pop('PROD_SUB1CONFIG_SUB2CONFIG_CONFIG_2', None)
+    os.environ.pop("DEBUG", None)
+    os.environ.pop("SUB1CONFIG_SUB2CONFIG_CONFIG_1", None)
+    os.environ.pop("PROD_SUB1CONFIG_SUB2CONFIG_CONFIG_2", None)
 
 
 def test_not_exist():
@@ -130,8 +130,8 @@ def test_default_name_field(update_environ):
     prod_config = ProdConfig()
 
     assert test_config.debug is True
-    assert test_config.Sub1Config.Sub2Config.config_1 == 'test.mail.com'
-    assert prod_config.Sub1Config.Sub2Config.config_2 == '100202'
+    assert test_config.Sub1Config.Sub2Config.config_1 == "test.mail.com"
+    assert prod_config.Sub1Config.Sub2Config.config_2 == "100202"
 
 
 def test_required_fields():
@@ -149,46 +149,42 @@ def test_fiend_name_is_none():
 
 def test_raise_abstract_provider():
     with pytest.raises(NotImplementedError):
-        AbstractProvider().get('test')
+        AbstractProvider().get("test")
 
 
 def test_raise_abstract_caster():
     with pytest.raises(NotImplementedError):
-        AbstractCaster().cast('test')
+        AbstractCaster().cast("test")
 
 
 def test_constant_caster():
     constant_caster = ConstantCaster()
 
-    constant_caster.ABLE_TO_CAST = {
-        ('key_1', 'key_2'): 'test'
-    }
-    assert constant_caster.cast('key_2') == 'test'
+    constant_caster.ABLE_TO_CAST = {("key_1", "key_2"): "test"}
+    assert constant_caster.cast("key_2") == "test"
 
-    constant_caster.ABLE_TO_CAST = {
-        'key_1': 'test'
-    }
-    assert constant_caster.cast('Key_1') == 'test'
+    constant_caster.ABLE_TO_CAST = {"key_1": "test"}
+    assert constant_caster.cast("Key_1") == "test"
 
-    assert isinstance(constant_caster.cast('key'), ImpossibleToCastError)
+    assert isinstance(constant_caster.cast("key"), ImpossibleToCastError)
 
 
 def test_raises_int_caster():
     int_caster = IntCaster()
-    assert isinstance(int_caster.cast('test'), ImpossibleToCastError)
+    assert isinstance(int_caster.cast("test"), ImpossibleToCastError)
 
 
 def test_to_dict():
     config = ProdConfig()
 
     assert as_dict(config) == {
-        '_prefix_': 'PROD',
-        'Sub1Config': {
-            'Sub2Config': {
-                'config_1': 'prod.mail.com',
-                'config_2': '465',
-                'config_3': 'test'
+        "_prefix_": "PROD",
+        "Sub1Config": {
+            "Sub2Config": {
+                "config_1": "prod.mail.com",
+                "config_2": "465",
+                "config_3": "test",
             },
         },
-        'debug': False
+        "debug": False,
     }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -166,12 +166,14 @@ def test_constant_caster():
     constant_caster.ABLE_TO_CAST = {"key_1": "test"}
     assert constant_caster.cast("Key_1") == "test"
 
-    assert isinstance(constant_caster.cast("key"), ImpossibleToCastError)
+    with pytest.raises(ImpossibleToCastError):
+        assert constant_caster.cast("key")
 
 
 def test_raises_int_caster():
     int_caster = IntCaster()
-    assert isinstance(int_caster.cast("test"), ImpossibleToCastError)
+    with pytest.raises(ImpossibleToCastError):
+        int_caster.cast("test")
 
 
 def test_to_dict():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from betterconf.caster import to_bool
 from betterconf.caster import to_int
 from betterconf.config import AbstractProvider, Field, as_dict
 from betterconf.config import VariableNotFoundError
+from betterconf.exceptions import ImpossibleToCastError
 
 VAR_1 = "hello"
 VAR_1_VALUE = "hello!#"
@@ -169,12 +170,12 @@ def test_constant_caster():
     }
     assert constant_caster.cast('Key_1') == 'test'
 
-    assert constant_caster.cast('key') == 'key'
+    assert isinstance(constant_caster.cast('key'), ImpossibleToCastError)
 
 
 def test_raises_int_caster():
     int_caster = IntCaster()
-    assert int_caster.cast('test') == 'test'
+    assert isinstance(int_caster.cast('test'), ImpossibleToCastError)
 
 
 def test_to_dict():


### PR DESCRIPTION
Since now user may choose: raise `ImpossibleToCastError` exception or return source value if the value cannot be casted with provided caster