### PR TITLE
Add more providers

### DIFF
--- a/betterconf/config.py
+++ b/betterconf/config.py
@@ -13,21 +13,6 @@ def is_callable(obj):
     return callable(obj)
 
 
-class AbstractProvider:
-    """Implement this class and pass to `field`"""
-
-    def get(self, name: str) -> typing.Any:
-        """Return a value or None"""
-        raise NotImplementedError()
-
-
-class EnvironmentProvider(AbstractProvider):
-    """Default provider. Gets vals from environment"""
-
-    def get(self, name: str) -> typing.Any:
-        return os.getenv(name)
-
-
 DEFAULT_PROVIDER = EnvironmentProvider()
 
 

--- a/betterconf/config.py
+++ b/betterconf/config.py
@@ -4,6 +4,7 @@ import typing
 from betterconf.caster import AbstractCaster
 from betterconf.caster import DEFAULT_CASTER
 from betterconf.exceptions import VariableNotFoundError, ImpossibleToCastError
+from betterconf.providers import DEFAULT_PROVIDER
 
 _NO_DEFAULT = object()
 
@@ -11,9 +12,6 @@ _NO_DEFAULT = object()
 def is_callable(obj):
     """Checks that object is callable (needed for default values)"""
     return callable(obj)
-
-
-DEFAULT_PROVIDER = EnvironmentProvider()
 
 
 class Field:

--- a/betterconf/providers.py
+++ b/betterconf/providers.py
@@ -1,0 +1,13 @@
+class AbstractProvider:
+    """Implement this class and pass to `field`"""
+
+    def get(self, name: str) -> typing.Any:
+        """Return a value or None"""
+        raise NotImplementedError()
+
+
+class EnvironmentProvider(AbstractProvider):
+    """Default provider. Gets vals from environment"""
+
+    def get(self, name: str) -> typing.Any:
+        return os.getenv(name)

--- a/betterconf/providers.py
+++ b/betterconf/providers.py
@@ -8,7 +8,7 @@ DEFAULT_PROVIDER = EnvironmentProvider()
 class AbstractProvider:
     """Implement this class and pass to `field`"""
 
-    def get(self, name: str) -> typing.Any:
+    def get(self, name: str) -> Any:
         """Return a value or None"""
         raise NotImplementedError()
 
@@ -16,7 +16,7 @@ class AbstractProvider:
 class EnvironmentProvider(AbstractProvider):
     """Default provider. Gets vals from environment"""
 
-    def get(self, name: str) -> typing.Any:
+    def get(self, name: str) -> Any:
         return os.getenv(name)
 
 class INIProvider(AbstractProvider):
@@ -39,5 +39,5 @@ class TOMLProvider(AbstractProvider):
     def __init__(self, files: Union[str, List[str]]):
         self.data = toml.load(files)
 
-    def get(self, name: str) -> str:
+    def get(self, name: str) -> Any:
         return self.data[name]

--- a/betterconf/providers.py
+++ b/betterconf/providers.py
@@ -1,7 +1,8 @@
 from configparser import ConfigParser
-from typing import Union, Any, Tuple, List
+from typing import Union, Any, Tuple, List, Sequence
 
 import toml
+import os
 
 DEFAULT_PROVIDER = EnvironmentProvider()
 
@@ -27,8 +28,9 @@ class INIProvider(AbstractProvider):
     def __init__(
         self,
         files: Union[str, List[str]],
-        delimiters: Tuple[str] = ("=", ":"),
-        comment_prefixes: Tuple[str] = ("#", ";"),
+        delimiters: Sequence[str] = ("=", ":"),
+        comment_prefixes: Sequence[str] = ("#", ";"),
+        section: str = "config"
     ):
         self.cfg = ConfigParser(
             delimiters=delimiters, comment_prefixes=comment_prefixes
@@ -36,9 +38,10 @@ class INIProvider(AbstractProvider):
         if isinstance(files, str):
             files = [files]
         self.cfg.read(files)
+        self.section = section
 
     def get(self, name: str) -> str:
-        return self.cfg.get(name)
+        return self.cfg.get(self.section, name)
 
 
 class TOMLProvider(AbstractProvider):

--- a/betterconf/providers.py
+++ b/betterconf/providers.py
@@ -1,3 +1,6 @@
+from configparser import ConfigParser
+from typing import Union, Any, Tuple, List
+
 class AbstractProvider:
     """Implement this class and pass to `field`"""
 
@@ -11,3 +14,17 @@ class EnvironmentProvider(AbstractProvider):
 
     def get(self, name: str) -> typing.Any:
         return os.getenv(name)
+
+class INIProvider(AbstractProvider):
+    """Provider that gets values from .INI files"""
+
+    def __init__(self, files: Union[str, List[str]],
+                 delimiters: Tuple[str] = ('=', ':'),
+                 comment_prefixes: Tuple[str] = ('#', ';')):
+        self.cfg = ConfigParser(delimiters=delimiters, comment_prefixes=comment_prefixes)
+        if isinstance(files, str):
+            files = [files]
+        self.cfg.read(files)
+
+    def get(self, name: str) -> str:
+        return self.cfg.get(name)

--- a/betterconf/providers.py
+++ b/betterconf/providers.py
@@ -5,6 +5,7 @@ import toml
 
 DEFAULT_PROVIDER = EnvironmentProvider()
 
+
 class AbstractProvider:
     """Implement this class and pass to `field`"""
 
@@ -19,19 +20,26 @@ class EnvironmentProvider(AbstractProvider):
     def get(self, name: str) -> Any:
         return os.getenv(name)
 
+
 class INIProvider(AbstractProvider):
     """Provider that gets values from .INI files"""
 
-    def __init__(self, files: Union[str, List[str]],
-                 delimiters: Tuple[str] = ('=', ':'),
-                 comment_prefixes: Tuple[str] = ('#', ';')):
-        self.cfg = ConfigParser(delimiters=delimiters, comment_prefixes=comment_prefixes)
+    def __init__(
+        self,
+        files: Union[str, List[str]],
+        delimiters: Tuple[str] = ("=", ":"),
+        comment_prefixes: Tuple[str] = ("#", ";"),
+    ):
+        self.cfg = ConfigParser(
+            delimiters=delimiters, comment_prefixes=comment_prefixes
+        )
         if isinstance(files, str):
             files = [files]
         self.cfg.read(files)
 
     def get(self, name: str) -> str:
         return self.cfg.get(name)
+
 
 class TOMLProvider(AbstractProvider):
     """Provider that gets values from .TOML files"""

--- a/betterconf/providers.py
+++ b/betterconf/providers.py
@@ -1,6 +1,8 @@
 from configparser import ConfigParser
 from typing import Union, Any, Tuple, List
 
+import toml
+
 DEFAULT_PROVIDER = EnvironmentProvider()
 
 class AbstractProvider:
@@ -30,3 +32,12 @@ class INIProvider(AbstractProvider):
 
     def get(self, name: str) -> str:
         return self.cfg.get(name)
+
+class TOMLProvider(AbstractProvider):
+    """Provider that gets values from .TOML files"""
+
+    def __init__(self, files: Union[str, List[str]]):
+        self.data = toml.load(files)
+
+    def get(self, name: str) -> str:
+        return self.data[name]

--- a/betterconf/providers.py
+++ b/betterconf/providers.py
@@ -1,10 +1,12 @@
 from configparser import ConfigParser
-from typing import Union, Any, Tuple, List, Sequence
+from typing import Union, Any, Tuple, List, Sequence, Callable, IO
 
 import toml
 import os
 
 DEFAULT_PROVIDER = EnvironmentProvider()
+
+TOMLLoadFunction = Callable[[Union[str, list, IO[str]]], dict]
 
 
 class AbstractProvider:
@@ -47,8 +49,8 @@ class INIProvider(AbstractProvider):
 class TOMLProvider(AbstractProvider):
     """Provider that gets values from .TOML files"""
 
-    def __init__(self, files: Union[str, List[str]]):
-        self.data = toml.load(files)
+    def __init__(self, load: TOMLLoadFunction, files: Union[str, List[str]]):
+        self.data = load(files)
 
     def get(self, name: str) -> Any:
         return self.data[name]

--- a/betterconf/providers.py
+++ b/betterconf/providers.py
@@ -1,6 +1,8 @@
 from configparser import ConfigParser
 from typing import Union, Any, Tuple, List
 
+DEFAULT_PROVIDER = EnvironmentProvider()
+
 class AbstractProvider:
     """Implement this class and pass to `field`"""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
+toml = "^0.10.1"
 
 [tool.poetry.dev-dependencies]
 black = "^19.10b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.6"
-toml = "^0.10.1"
 
 [tool.poetry.dev-dependencies]
 black = "^19.10b0"


### PR DESCRIPTION
I moved `AbstractProvider` and `EnvironmentProvider` to `providers.py`.
Also I added two more providers:
- `INIProvider` that reads from a set section in 1+ INI files,
- and `TOMLProvider` that reads the variables from 1+ TOML files.

`TOMLProvider` has a external dependency from PyPI: `toml` which I added to `pyproject.toml`.

